### PR TITLE
gtk-widgets: colors for GtkHTML control

### DIFF
--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -744,4 +744,7 @@ GtkAssistant .sidebar .highlight {
 	color: @fg_normal;
 }
 
-
+GtkHTML {
+    color: @fg_normal;
+    background-color: @bg_normal;
+}


### PR DESCRIPTION
It is used in Evolution mail client. If we don't set the colors, the
background ends up some light-gray color. With this patch it looks fully
integrated.
